### PR TITLE
Fix plugin close scanning

### DIFF
--- a/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotDropDownReceiver.java
+++ b/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotDropDownReceiver.java
@@ -69,6 +69,11 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
     /**************************** PUBLIC METHODS *****************************/
 
     public void disposeImpl() {
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+            scanning = false;
+        }
     }
 
     /**************************** INHERITED METHODS *****************************/
@@ -133,6 +138,11 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
 
     @Override
     public void onDropDownClose() {
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+            scanning = false;
+        }
     }
 
     public void compute() {


### PR DESCRIPTION
## Summary
- stop scanning timer when the plugin closes

## Testing
- `./gradlew test` *(fails: No route to host)*