### PR TITLE
Fix lifecycle log message

### DIFF
--- a/app/src/main/java/com/atakmap/android/wifi2cot/plugin/wifi2cotLifecycle.java
+++ b/app/src/main/java/com/atakmap/android/wifi2cot/plugin/wifi2cotLifecycle.java
@@ -14,6 +14,6 @@ public class wifi2cotLifecycle extends AbstractPlugin implements IPlugin {
 
     public wifi2cotLifecycle(IServiceController serviceController) {
         super(serviceController, new wifi2cotTool(serviceController.getService(PluginContextProvider.class).getPluginContext()), new wifi2cotMapComponent());
-        Log.d(TAG, "wifi2cotLifcycle");
+        Log.d(TAG, "wifi2cotLifecycle");
     }
 }


### PR DESCRIPTION
## Summary
- ensure wifi2cotLifecycle constructor logs correct tag

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*